### PR TITLE
support for open session

### DIFF
--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -326,6 +326,12 @@ class FabricModule(CFSNode):
             enable = 0
         fwrite(path, "%s" % enable)
 
+    def _check_for_sessions(self):
+        for target in self.targets:
+            if target.has_sessions:
+                return True
+        return False
+
     discovery_userid = \
             property(_get_discovery_userid,
                      _set_discovery_userid,
@@ -352,6 +358,12 @@ class FabricModule(CFSNode):
 
     version = property(_get_version,
                        doc="Get the fabric module version string.")
+
+    has_sessions = \
+            property(_check_for_sessions,
+                     doc="Whether or not this FabricModule has open sessions.")
+    '''@type: C{bool}'''
+
 
     def setup(self, fm):
         '''
@@ -1301,6 +1313,12 @@ class TPG(CFSNode):
         return "%s/%s+%d"  \
                 % (self.alua_metadata_dir, self.parent_target.wwn, self.tag)
 
+    def _check_for_sessions(self):
+        for acl in self.node_acls:
+            if acl.session is not None:
+                return True
+        return False
+
     # TPG public stuff
 
     def has_feature(self, feature):
@@ -1380,6 +1398,10 @@ class TPG(CFSNode):
     nexus = property(_get_nexus, _set_nexus,
                      doc="Get or set (once) the TPG's Nexus is used.")
 
+    has_sessions = property(_check_for_sessions,
+            doc="Whether or not this TPG has open sessions.")
+    '''@type: C{bool}'''
+
     def dump(self):
         d = super(TPG, self).dump()
         d['tag'] = self.tag
@@ -1454,6 +1476,12 @@ class Target(CFSNode):
             tag = int(tag)
             yield TPG(self, tag, 'lookup')
 
+    def _check_for_sessions(self):
+        for tpg in self.tpgs:
+            if tpg.has_sessions:
+                return True
+        return False
+
     # Target public stuff
 
     def has_feature(self, feature):
@@ -1473,6 +1501,10 @@ class Target(CFSNode):
         super(Target, self).delete()
 
     tpgs = property(_list_tpgs, doc="Get the list of TPG for the Target.")
+
+    has_sessions = property(_check_for_sessions,
+            doc="Whether or not this Target has open sessions.")
+    '''@type: C{bool}'''
 
     @classmethod
     def setup(cls, fm_obj, storage_objects, t):


### PR DESCRIPTION
See #10 for the corresponding issue.

This adds two classes: `Session` and `Connection`.
`NodeACL` now has a `session` property that takes a snapshot of the current open session or is `None`.

I also inluded `has_sessions` in `FabricModule, Target` and `TPG`. This is not part of the core feature, but handy for listing only the parts of the tree with open sessions.
You can just merge 5e88ec215548a1f990df3eb4d70bb9a2fbafc686 to include the two core commits.

I updated my [targetstatus prototype](https://github.com/JonnyJD/targetcli-fb/blob/status/scripts/targetstatus) as a usage example of the new rtslib session API.
