### PR TITLE
fix MappedLun typo

### DIFF
--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -952,7 +952,7 @@ class NodeACL(CFSNode):
         set_attributes(acl_obj, acl.get('attributes', {}))
 
         for mlun in acl.get('mapped_luns', []):
-            MappedLun.setup(tpg_obj, acl_obj, mlun, err_func)
+            MappedLUN.setup(tpg_obj, acl_obj, mlun, err_func)
 
         dict_remove(acl, ('attributes', 'mapped_luns', 'node_wwn'))
         for name, value in acl.iteritems():


### PR DESCRIPTION
Introduced in c37a00b93bff4d89b28992e7c4e6d1fa98351b74, which is released in fb38 and fb39.

The reported error while starting the target service was:

```
Traceback (most recent call last):
File "/usr/bin/targetcli", line 89, in <module>
main()
File "/usr/bin/targetcli", line 72, in main
shell.run_cmdline(" ".join(sys.argv[1:]))
File "/usr/lib/python2.7/site-packages/configshell/shell.py", line 934, in run_cmdline
self._execute_command(path, command, pparams, kparams)
File "/usr/lib/python2.7/site-packages/configshell/shell.py", line 909, in _execute_command
result = target.execute_command(command, pparams, kparams)
File "/usr/lib/python2.7/site-packages/targetcli/ui_node.py", line 87, in execute_command
pparams, kparams)
File "/usr/lib/python2.7/site-packages/configshell/node.py", line 1417, in execute_command
result = method(*pparams, **kparams)
File "/usr/lib/python2.7/site-packages/targetcli/ui_root.py", line 108, in ui_command_restoreconfig
errors = RTSRoot().restore(json.loads(f.read()), clear_existing)
File "/usr/lib/python2.7/site-packages/rtslib/root.py", line 213, in restore
Target.setup(fm_obj, t, err_func)
File "/usr/lib/python2.7/site-packages/rtslib/target.py", line 130, in setup
TPG.setup(t_obj, tpg, err_func)
File "/usr/lib/python2.7/site-packages/rtslib/target.py", line 418, in setup
NodeACL.setup(tpg_obj, acl, err_func)
File "/usr/lib/python2.7/site-packages/rtslib/target.py", line 955, in setup
MappedLun.setup(tpg_obj, acl_obj, mlun, err_func)
NameError: global name 'MappedLun' is not defined

target.service: main process exited, code=exited, status=1/FAILURE
Failed to start Restore LIO kernel target configuration.
Unit target.service entered failed state.
```

reported in https://aur.archlinux.org/packages/targetcli-fb/ (Arch Linux packaging for tagetcli-fb)
