### PR TITLE
Depend on pyudev during runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup (
     url = 'http://github.com/open-iscsi/rtslib-fb',
     packages = ['rtslib_fb', 'rtslib'],
     scripts = ['scripts/targetctl'],
+    install_requires = ['pyudev >= 0.16.1'],
     classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
In v2.1.fb60 an unconditional dependency to pyudev was added,
which needs to be specified in the egg info, otherwise pip install might fail with e.g.

File "local/lib/python2.7/site-packages/rtslib/utils.py", line 30, in <module>
     import pyudev
 ImportError: No module named pyudev