### PR TITLE
Do not raise exceptions if alua_tg_pt_gp is absent

### DIFF
--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -586,22 +586,22 @@ class LUN(CFSNode):
         self._check_self()
 
         path = "%s/alua_tg_pt_gp" % self.path
-        info = fread(path)
-        if info:
+        try:
+            info = fread(path)
             group_line = info.splitlines()[0]
             return group_line.split(':')[1].strip()
-        return None
+        except IOError as e:
+            # Will not always be present
+            return None
 
     def _set_alua_tg_pt_gp_name(self, group_name):
         self._check_self()
 
         path = "%s/alua_tg_pt_gp" % self.path
 
-        info = fread(path)
-        if not info:
-            # pass through backends will not have setup the default
-            # ALUA structs in the kernel.
-            raise RTSLibError("This LUN does not support setting the ALUA Target Port Group")
+        # This will not exist for pass-through backends
+        if not os.path.exists(path):
+            return
 
         try:
             fwrite(path, group_name)


### PR DESCRIPTION
In both get and set cases, do not raise exceptions if there are failures
because the configfs entry is missing.

Signed-off-by: Andy Grover <agrover@redhat.com>