### PR TITLE
Fix crash during restore due to ALUA exception

### DIFF
--- a/rtslib/__init__.py
+++ b/rtslib/__init__.py
@@ -23,6 +23,7 @@ if __name__ == "rtslib":
 
 from .root import RTSRoot
 from .utils import RTSLibError, RTSLibBrokenLink, RTSLibNotInCFS
+from .utils import RTSLibALUANotSupported
 
 from .target import LUN, MappedLUN
 from .target import NodeACL, NetworkPortal, TPG, Target

--- a/rtslib/alua.py
+++ b/rtslib/alua.py
@@ -18,7 +18,7 @@ a copy of the License at
 '''
 
 from .node import CFSNode
-from .utils import RTSLibError, fread, fwrite
+from .utils import RTSLibError, RTSLibALUANotSupported, fread, fwrite
 
 alua_rw_params = ['alua_access_state', 'alua_access_status',
                   'alua_write_metadata', 'alua_access_type', 'preferred',
@@ -46,6 +46,12 @@ class ALUATargetPortGroup(CFSNode):
         @param tag: target port group id. If not passed in, try to look
                     up existing ALUA TPG with the same name
         """
+        # kernel partially sets up default_tg_pt_gp and will let you partially
+        # setup ALUA groups for pscsi and user, but writing to some of the
+        # files will crash the kernel. Just fail to even create groups until
+        # the kernel is fixed.
+        if storage_object.alua_supported is False:
+            raise RTSLibALUANotSupported("Backend does not support ALUA setup")
 
         # default_tg_pt_gp takes tag 1
         if tag is not None and (tag > 65535 or tag < 1):

--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -26,7 +26,7 @@ from .node import CFSNode
 from .target import Target
 from .fabric import FabricModule
 from .tcm import so_mapping, StorageObject
-from .utils import RTSLibError, modprobe, mount_configfs
+from .utils import RTSLibError, RTSLibALUANotSupported, modprobe, mount_configfs
 from .utils import dict_remove, set_attributes
 from .alua import ALUATargetPortGroup
 
@@ -224,7 +224,10 @@ class RTSRoot(CFSNode):
             set_attributes(so_obj, so.get('attributes', {}), so_err_func)
 
             for alua_tpg in so.get('alua_tpgs', {}):
-                ALUATargetPortGroup.setup(so_obj, alua_tpg, err_func)
+               try:
+                   ALUATargetPortGroup.setup(so_obj, alua_tpg, err_func)
+               except RTSLibALUANotSupported:
+                   pass
 
         # Don't need to create fabric modules
         for index, fm in enumerate(config.get('fabric_modules', [])):

--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -37,6 +37,12 @@ class RTSLibError(Exception):
     '''
     pass
 
+class RTSLibALUANotSupported(RTSLibError):
+    '''
+    Backend does not support ALUA.
+    '''
+    pass
+
 class RTSLibBrokenLink(RTSLibError):
     '''
     Broken link in configfs, i.e. missing LUN storage object.


### PR DESCRIPTION
The following patches fix the targetctl crash due to the ALUA setup failing and raising an exception.

The patches also make so you cannot even create ALUA groups on backends that do not fully support ALUA.