### PR TITLE
ALUA: return list of members

### DIFF
--- a/rtslib/alua.py
+++ b/rtslib/alua.py
@@ -248,7 +248,17 @@ class ALUATargetPortGroup(CFSNode):
     def _get_members(self):
         self._check_self()
         path = "%s/members" % self.path
-        return fread(path)
+
+        member_list = []
+
+        for member in fread(path).splitlines():
+            lun_path = member.split("/")
+            if len(lun_path) != 4:
+                continue
+            member_list.append({ 'driver': lun_path[0], 'target': lun_path[1],
+                                 'tpgt': int(lun_path[2].split("_", 1)[1]),
+                                 'lun': int(lun_path[3].split("_", 1)[1]) })
+        return member_list
 
     def _get_tg_pt_gp_id(self):
         self._check_self()


### PR DESCRIPTION
There is a bug in the kernel where if you map a backend device through
multiple targets/tpgts it only returns the first one. The rtslib
ALUA members function then returns a string containing whatever the kernel
prints out which is just the first lun the backend is mapped to. The
others are dropped. When the kernel is fixed this will print out a lun
mapping per line with the format:

driver/target/tpgt/lun\n

for each mapping.

This patch prepares us for the kernel getting fixed and returns
the lun mappings in a format that is easier for the rtslib user.

It will return a list of dictionarys with the format:

[{'tpgt': 'tpgt_1', 'driver': 'iSCSI', 'target':
'iqn.1999-09.com.tcmu:alua', 'lun': 'lun_3'}, {'tpgt': 'tpgt_2',
'driver': 'iSCSI', 'target': 'iqn.1999-09.com.tcmu:alua2', 'lun':
'lun_1'}]