### PR TITLE
Switch target driver DB root dir to /etc/target

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -78,7 +78,8 @@ class StorageObject(CFSNode):
         need to read it in and squirt it back into configfs when we configure
         the storage object. BLEH.
         """
-        aptpl_dir = "/var/target/pr"
+        from .root import RTSRoot
+        aptpl_dir = "%s/pr" % RTSRoot().dbroot
 
         try:
             lines = fread("%s/aptpl_%s" % (aptpl_dir, self.wwn)).split()


### PR DESCRIPTION
This switches the kernel target driver directory from
the default of /var/target to /etc/target, if the
"dbroot" sysfs attribute is present. If not, the default
of /var/target is maintained. This has to be done
by rtslib/root.py since this module loads the
target_core_mod module, where the dbroot value
must be updated before any target_core_* drivers
register with target_core_mod.