### PR TITLE
Switch target driver DB root dir to /etc/target

### DIFF
--- a/config/rtslib.cfg
+++ b/config/rtslib.cfg
@@ -1,0 +1,11 @@
+[root]
+# set dbroot to where you want your target driver database
+# root directory -- defaults to "/var/target" if not set
+# NOTE: if you change this, then:
+#  1 - stop all I/O to your target
+#  2 - copy the directories under the previous location
+#      to your new location e.g.:
+#          # cp -r /var/target/* /etc/target
+#  3 - reboot your system, for the new value to take
+#      effect
+dbroot: "/etc/target"

--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -28,6 +28,7 @@ from .fabric import FabricModule
 from .tcm import so_mapping, bs_cache, StorageObject
 from .utils import RTSLibError, RTSLibALUANotSupported, modprobe, mount_configfs
 from .utils import dict_remove, set_attributes
+from .utils import fread, fwrite
 from .alua import ALUATargetPortGroup
 
 default_save_file = "/etc/target/saveconfig.json"
@@ -57,6 +58,10 @@ class RTSRoot(CFSNode):
     '''
 
     # RTSRoot private stuff
+
+    # this should match the kernel target driver default db dir
+    _default_dbroot = "/var/target"
+
     def __init__(self):
         '''
         Instantiate an RTSRoot object. Basically checks for configfs setup and
@@ -74,6 +79,8 @@ class RTSRoot(CFSNode):
         except RTSLibError:
             modprobe('target_core_mod')
             self._create_in_cfs_ine('any')
+
+        self._get_dbroot_from_sysfs()
 
     def _list_targets(self):
         self._check_self()
@@ -147,6 +154,15 @@ class RTSRoot(CFSNode):
 
     def __str__(self):
         return "rtslib"
+
+    def _get_dbroot(self):
+        return self._dbroot
+
+    def _get_dbroot_from_sysfs(self):
+        try:
+            self._dbroot = fread(self.path+"/dbroot")
+        except IOError:
+            self._dbroot = _default_dbroot
 
     # RTSRoot public stuff
 
@@ -296,6 +312,13 @@ class RTSRoot(CFSNode):
         '''
         bs_cache.clear()
 
+    def set_dbroot(self, new_dbroot):
+        fwrite(self.path+"/dbroot", new_dbroot+"\n")
+        self._get_dbroot_from_sysfs()
+        if self._dbroot != new_dbroot:
+            raise RTSLibError("Set 'dbroot' to '%s' but it is '%s'" % \
+                              (new_dbroot, self._dbroot))
+
     targets = property(_list_targets,
             doc="Get the list of Target objects.")
     tpgs = property(_list_tpgs,
@@ -320,6 +343,8 @@ class RTSRoot(CFSNode):
             doc="Get the list of all FabricModule objects.")
     alua_tpgs = property(_list_alua_tpgs,
             doc="Get the list of all ALUA TPG objects.")
+    dbroot = property(_get_dbroot,
+            doc="Get the target database root")
 
 def _test():
     '''Run the doctests.'''

--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -78,7 +78,8 @@ class StorageObject(CFSNode):
         need to read it in and squirt it back into configfs when we configure
         the storage object. BLEH.
         """
-        aptpl_dir = "/var/target/pr"
+        from .root import RTSRoot
+        aptpl_dir = "%s/pr" % RTSRoot().dbroot
 
         try:
             lines = fread("%s/aptpl_%s" % (aptpl_dir, self.wwn)).split()

--- a/scripts/dbrootctl
+++ b/scripts/dbrootctl
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+'''
+dbrootctl -- Set or get the target driver database root directory
+
+This file is part of RTSLib.
+Copyright (c) 2013 by Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+'''
+
+#
+# A script to set or get the dbroot directory
+#
+
+from __future__ import print_function
+
+from rtslib_fb import RTSRoot
+import os
+import sys
+from ConfigParser import ConfigParser
+
+config_file = "/etc/target/rtslib.cfg"
+err = sys.stderr
+
+def usage():
+    print("syntax: %s set_from_config" % sys.argv[0], file=err)
+    print("        %s get" % sys.argv[0], file=err)
+    print("  config file is: %s" % config_file, file=err)
+
+def set_dbroot_from_config():
+    # get config file value
+    config = ConfigParser()
+    config.read(config_file)
+    try:
+        new_dbroot = config.get("root", "dbroot")
+    except Exception:
+        print("No 'dbroot' configuration found", file=err)
+        return False
+    # use rtslib root object to set dbroot
+    root = RTSRoot()
+    if root.dbroot != new_dbroot:
+        try:
+            print("Setting target driver database root to %s" % new_dbroot)
+            root.set_dbroot(new_dbroot)
+        except Exception as e:
+            print("Cannot set dbroot: %s" % e.message, file=err)
+            return False
+    return True
+
+def get_dbroot():
+    # use rtslib root object to get dbroot
+    print("%s\n" % RTSRoot().dbroot)
+    return True
+
+funcs = dict(set_from_config=set_dbroot_from_config, get=get_dbroot)
+
+def main():
+    if os.geteuid() != 0:
+        print("Must run as root", file=err)
+        sys.exit(-1)
+
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(-1)
+
+    if sys.argv[1] == "--help":
+        usage()
+        sys.exit(0)
+
+    if sys.argv[1] not in funcs.keys():
+        usage()
+        sys.exit(-1)
+
+    if not funcs[sys.argv[1]]():
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup (
     url = 'http://github.com/open-iscsi/rtslib-fb',
     packages = ['rtslib_fb', 'rtslib'],
     scripts = ['scripts/targetctl'],
+    data_files = [('/etc', ['config/rtslib.cfg'])],
     install_requires = ['pyudev >= 0.16.1'],
     classifiers = [
         "Programming Language :: Python",


### PR DESCRIPTION
This switches the kernel target driver directory from
the default of /var/target to /etc/target, if the
"dbroot" sysfs attribute is present. If not, the default
of /var/target is maintained. This has to be done
by rtslib/root.py since this module loads the
target_core_mod module, where the dbroot value
must be updated before any target_core_* drivers
register with target_core_mod.

The switching is done via a new configuration file in
/etc/target called rtslib.cfg, which allows
this directory location to be modified.