### PR TITLE
alua: enable alua for pscsi/tcmu if kernel reports support

### DIFF
--- a/rtslib/alua.py
+++ b/rtslib/alua.py
@@ -46,10 +46,6 @@ class ALUATargetPortGroup(CFSNode):
         @param tag: target port group id. If not passed in, try to look
                     up existing ALUA TPG with the same name
         """
-        # kernel partially sets up default_tg_pt_gp and will let you partially
-        # setup ALUA groups for pscsi and user, but writing to some of the
-        # files will crash the kernel. Just fail to even create groups until
-        # the kernel is fixed.
         if storage_object.alua_supported is False:
             raise RTSLibALUANotSupported("Backend does not support ALUA setup")
 


### PR DESCRIPTION
4.14 (it is currently the 4.13 feature window and I think we will
miss it) will add this patch

https://git.kernel.org/pub/scm/linux/kernel/git/nab/target-pending.git/commit/?h=for-next&id=c17d5d5f51f72f24e0e17a4450ae5010bf6962d9

commit c17d5d5f51f72f24e0e17a4450ae5010bf6962d9
Author: Mike Christie <mchristi@redhat.com>
Date:   Mon Jul 10 14:53:31 2017 -0500

    target: export lio pgr/alua support as device attr

which has the lio device report if it supports lio based ALUA.

This patch has rtslib check the configfs alua_support file for pscsi and tcmu to check if alua is supported in the kernel. Note that we only check for those two, because older kernels always supported ALUA for backends like iblock and file and so they should return true even if the alua_support file does not exist in configfs. For pscsi and tcmu it is the opposite and we need to return false if that file does not exist.