### PR TITLE
Fix python 3.6 escape char warnings in strings

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -378,12 +378,12 @@ def normalize_wwn(wwn_types, wwn):
     wwn_test = {
     'free': lambda wwn: True,
     'iqn': lambda wwn: \
-        re.match("iqn\.[0-9]{4}-[0-1][0-9]\..*\..*", wwn) \
+        re.match(r"iqn\.[0-9]{4}-[0-1][0-9]\..*\..*", wwn) \
         and not re.search(' ', wwn) \
         and not re.search('_', wwn),
-    'naa': lambda wwn: re.match("naa\.[125][0-9a-fA-F]{15}$", wwn),
-    'eui': lambda wwn: re.match("eui\.[0-9a-f]{16}$", wwn),
-    'ib': lambda wwn: re.match("ib\.[0-9a-f]{32}$", wwn),
+    'naa': lambda wwn: re.match(r"naa\.[125][0-9a-fA-F]{15}$", wwn),
+    'eui': lambda wwn: re.match(r"eui\.[0-9a-f]{16}$", wwn),
+    'ib': lambda wwn: re.match(r"ib\.[0-9a-f]{32}$", wwn),
     'unit_serial': lambda wwn: \
         re.match("[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$", wwn),
     }


### PR DESCRIPTION
In python 3.6, escape sequences that are not
recognized in string literals issue DeprecationWarnings.

Convert these to raw strings.