### PR TITLE
Display a more meaningful error when targetcli cannot change "dbroot"

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -164,7 +164,11 @@ class RTSRoot(CFSNode):
             return
         self._dbroot = fread(dbroot_path)
         if self._dbroot != self._preferred_dbroot:
-            fwrite(dbroot_path, self._preferred_dbroot+"\n")
+            try:
+                fwrite(dbroot_path, self._preferred_dbroot+"\n")
+            except:
+                raise RTSLibError("Cannot set dbroot to {}. Please check if this directory exists."
+                                  .format(self._preferred_dbroot))
             self._dbroot = fread(dbroot_path)
 
     def _get_dbroot(self):


### PR DESCRIPTION
The "dbroot" configfs parameter allows to set the directory where
persistent information are stored by the kernel, such as persistent
reservations or ALUA.

Targetcli tries to change the value of the "dbroot" parameter from
/var/target/ to /etc/target/. However, if the directory passed to
"dbroot" does not exist, the kernel returns an "invalid argument"
error:

    # targetcli
    [Errno 22] Invalid argument

With this patch, a more meaningful message is displayed instead:

    # targetcli
    Cannot set dbroot to /etc/target. Please check if this directory exists.

This patch fixes issue #103.

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>