### PR TITLE
Raise an error about failing to change the dbroot value only if the d…

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -167,8 +167,9 @@ class RTSRoot(CFSNode):
             try:
                 fwrite(dbroot_path, self._preferred_dbroot+"\n")
             except:
-                raise RTSLibError("Cannot set dbroot to {}. Please check if this directory exists."
-                                  .format(self._preferred_dbroot))
+                if not os.path.isdir(self._preferred_dbroot):
+                    raise RTSLibError("Cannot set dbroot to {}. Please check if this directory exists."
+                                      .format(self._preferred_dbroot))
             self._dbroot = fread(dbroot_path)
 
     def _get_dbroot(self):


### PR DESCRIPTION
…irectory does not exist

This allows targetcli to start when the dbroot value cannot be changed
because the target drivers are already registered (issue #105).

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>