### PR TITLE
tcm.py: allow ':' in config string

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -822,8 +822,6 @@ class UserBackedStorageObject(StorageObject):
     def _configure(self, config, size, wwn, hw_max_sectors):
         self._check_self()
 
-        if ':' in config:
-            raise RTSLibError("':' not allowed in config string")
         self._control("dev_config=%s" % config)
         self._control("dev_size=%d" % size)
         if hw_max_sectors is not None:


### PR DESCRIPTION
There is need to config glusterfs storage in targetcli with qemu-tcmu which like this:

    backstores/user:qemu/ create test3 10G @gluster://NODE1/block-store/qemu.qcow2

And potentially ':' can be used for options configure.

Signed-off-by: Yaowei Bai <baiyaowei@cmss.chinamobile.com>