### PR TITLE
fix invalid literal error for attributes

### DIFF
--- a/rtslib/node.py
+++ b/rtslib/node.py
@@ -215,7 +215,7 @@ class CFSNode(object):
         params = {}
         for item in self.list_attributes(writable=True):
             try:
-                attrs[item] = int(self.get_attribute(item))
+                attrs[item] = self.get_attribute(item)
             except ValueError:
                 attrs[item] = self.get_attribute(item)
         if attrs:


### PR DESCRIPTION
fix invalid literal error for attributes

This patch removes a convert string to int for attributes. 

Fixes https://github.com/open-iscsi/rtslib-fb/issues/108