### PR TITLE
More compatibility syntax for legacy distros

### DIFF
--- a/rtslib/fabric.py
+++ b/rtslib/fabric.py
@@ -118,8 +118,8 @@ from .utils import RTSLibError, modprobe, ignored
 from .target import Target
 from .utils import _get_auth_attr, _set_auth_attr
 
-version_attributes = {"lio_version", "version"}
-discovery_auth_attributes = {"discovery_auth"}
+version_attributes = set(["lio_version", "version"])
+discovery_auth_attributes = set(["discovery_auth"])
 target_names_excludes = version_attributes | discovery_auth_attributes
 
 


### PR DESCRIPTION
Many distros(such as CentOS 6) still use python 2.6. but in fabric.py, uses new set
initialization syntax introduced by python 2.7

We can consider for legacy distros using python 2.6 as we using legacy but not
deprecated syntax

Signed-off-by: Ji-Hyeon Gim <potatogim@potatogim.net>