### PR TITLE
create: remove stale hba-only dir

### DIFF
--- a/rtslib/node.py
+++ b/rtslib/node.py
@@ -52,9 +52,16 @@ class CFSNode(object):
         '''
         if mode not in ['any', 'lookup', 'create']:
             raise RTSLibError("Invalid mode: %s" % mode)
+
         if self.exists and mode == 'create':
-            raise RTSLibError("This %s already exists in configFS"
-                              % self.__class__.__name__)
+            # ensure that self.path is not stale hba-only dir
+            if os.path.samefile(os.path.dirname(self.path), self.configfs_dir+'/core') \
+               and not next(os.walk(self.path))[1]:
+                os.rmdir(self.path)
+            else:
+               raise RTSLibError("This %s already exists in configFS"
+                                 % self.__class__.__name__)
+
         elif not self.exists and mode == 'lookup':
             raise RTSLibNotInCFS("No such %s in configfs: %s"
                                  % (self.__class__.__name__, self.path))


### PR DESCRIPTION
curretly if there exist any stale hba-only directories,

$ ls /sys/kernel/config/target/core/user_0/
hba_info  hba_mode

Then backend creation fails,

$ targetcli /backstores/fileio create block file 1M
This _Backstore already exists in configFS

We will have to restart target.service or restore the configuration
again to clear the stale hba-only dirs.

This patch checks for hba directory before creating one,
if it is already existing and found to be stale then removes it.

Thanks to "Maurizio Lombardi <mlombard@redhat.com>" for debugging along

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>