### PR TITLE
Split tcmu create and enable

### DIFF
--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -29,6 +29,7 @@ from .utils import RTSLibBrokenLink, RTSLibError
 from .utils import fread, fwrite, normalize_wwn, generate_wwn
 from .utils import dict_remove, set_attributes, set_parameters, ignored
 from .utils import _get_auth_attr, _set_auth_attr
+from .utils import set_enable, get_enable
 from . import tcm
 
 import six
@@ -221,29 +222,6 @@ class TPG(CFSNode):
             port = int(port)
             yield NetworkPortal(self, ip_address, port, 'lookup')
 
-    def _get_enable(self):
-        self._check_self()
-        path = "%s/enable" % self.path
-        # If the TPG does not have the enable attribute, then it is always
-        # enabled.
-        if os.path.isfile(path):
-            return bool(int(fread(path)))
-        else:
-            return True
-
-    def _set_enable(self, boolean):
-        '''
-        Enables or disables the TPG. If the TPG doesn't support the enable
-        attribute, do nothing.
-        '''
-        self._check_self()
-        path = "%s/enable" % self.path
-        if os.path.isfile(path) and (boolean != self._get_enable()):
-            try:
-                fwrite(path, str(int(boolean)))
-            except IOError as e:
-                raise RTSLibError("Cannot change enable state: %s" % e)
-
     def _get_nexus(self):
         '''
         Gets the nexus initiator WWN, or None if the TPG does not have one.
@@ -372,7 +350,7 @@ class TPG(CFSNode):
     parent_target = property(_get_parent_target,
                              doc="Get the parent Target object to which the " \
                              + "TPG is attached.")
-    enable = property(_get_enable, _set_enable,
+    enable = property(get_enable, set_enable,
                       doc="Get or set a boolean value representing the " \
                       + "enable status of the TPG. " \
                       + "True means the TPG is enabled, False means it is " \

--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -132,21 +132,18 @@ class StorageObject(CFSNode):
 
     def _get_wwn(self):
         self._check_self()
-        if self.enable:
-            path = "%s/wwn/vpd_unit_serial" % self.path
-            return fread(path).partition(":")[2].strip()
-        else:
+        path = "%s/wwn/vpd_unit_serial" % self.path
+        serial = fread(path).partition(":")[2].strip()
+        if not serial:
             raise RTSLibError("Cannot read a T10 WWN Unit Serial from "
                               + "an unconfigured StorageObject")
+        else:
+            return serial
 
     def _set_wwn(self, wwn):
         self._check_self()
-        if self.enable:
-            path = "%s/wwn/vpd_unit_serial" % self.path
-            fwrite(path, "%s\n" % wwn)
-        else:
-            raise RTSLibError("Cannot write a T10 WWN Unit Serial to "
-                              + "an unconfigured StorageObject")
+        path = "%s/wwn/vpd_unit_serial" % self.path
+        fwrite(path, "%s\n" % wwn)
 
     def _set_udev_path(self, udev_path):
         self._check_self()

--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -511,6 +511,32 @@ def set_parameters(obj, param_dict, err_func):
         except RTSLibError as e:
             err_func(str(e))
 
+def get_enable(so):
+    '''
+    @return: True if the StorageObject is configured, else returns False
+    '''
+    so._check_self()
+    path = "%s/enable" % so.path
+    # Some TPGs do not have the enable attribute, so they are always
+    # enabled.
+    if os.path.isfile(path):
+        return bool(int(fread(path)))
+    else:
+        return True
+
+def set_enable(so, boolean):
+    '''
+    Enables or disables the object. If id doesn't support the enable
+    attribute, do nothing.
+    '''
+    so._check_self()
+    path = "%s/enable" % so.path
+    if os.path.isfile(path) and (boolean != so.enable):
+        try:
+            fwrite(path, str(int(boolean)))
+        except IOError as e:
+            raise RTSLibError("Cannot change enable state: %s" % e)
+
 def _test():
     '''Run the doctests'''
     import doctest


### PR DESCRIPTION
The following patches add the base infrastructure to split device creation and enablement.

This is needed for the following:

1. To set "control" settings (/sys/kernel/config/target/core/user_0/dev/control) like MaxDataAreaMB we must set the value before doing the "enable". Currently when we add a new setting we have to modify rtslib and targetcli. These patches separate the enable step from creation so we can set the control values like we do attributes and parameters.

Note that these patches do not add functionality like get/set_control, because I am not done with that part yet. The gluster devs needed the split feature for the next item so I am posting this early so they can work on it.

2. It is common for the runner backend to hit temp issues with its transport during start up.  If this happens, we currently destroy the backend device and do not set other things up like the lun exports. Later, when the admin has fixed the problem they have to go an resetup everything. With these patches the device and its exports will still be there and the user just has to do the enable command like they do for tpgs.