### PR TITLE
Add read_mbytes and write_mbytes from statistics

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -191,6 +191,14 @@ class StorageObject(CFSNode):
         self._check_self()
         return self._parse_info('Status').lower()
 
+    def _get_read_mbytes(self):
+        self._check_self()
+        return int(fread("%s/statistics/scsi_lu/read_mbytes" % self.path))
+
+    def _get_write_mbytes(self):
+        self._check_self()
+        return int(fread("%s/statistics/scsi_lu/read_mbytes" % self.path))
+
     def _gen_attached_luns(self):
         '''
         Fast scan of luns attached to a storage object. This is an order of
@@ -303,6 +311,12 @@ class StorageObject(CFSNode):
             doc="Get list of ALUA Target Port Groups attached.")
     alua_supported = property(_get_alua_supported,
             doc="Returns true if ALUA can be setup. False if not supported.")
+
+    read_mbytes = property(_get_read_mbytes,
+            doc="Get the number of megabytes read from this StorageObject")
+
+    write_mbytes = property(_get_write_mbytes,
+            doc="Get the number of megabytes written to this StorageObject")
 
     def dump(self):
         d = super(StorageObject, self).dump()


### PR DESCRIPTION
This is a bit awkward at the moment, and should perhaps be refactored
into more statistical helpers, but for now, being able to grab the
read/write count to the device is fairly handy.