### PR TITLE
restoreconfig: fix alua tpg config setup

### DIFF
--- a/rtslib/alua.py
+++ b/rtslib/alua.py
@@ -19,6 +19,7 @@ a copy of the License at
 
 from .node import CFSNode
 from .utils import RTSLibError, RTSLibALUANotSupported, fread, fwrite
+import six
 
 alua_rw_params = ['alua_access_state', 'alua_access_status',
                   'alua_write_metadata', 'alua_access_type', 'preferred',
@@ -393,5 +394,10 @@ class ALUATargetPortGroup(CFSNode):
             return
 
         alua_tpg_obj = cls(storage_obj, name, alua_tpg['tg_pt_gp_id'])
-        for param in alua_rw_params:
-            setattr(alua_tpg_obj, param, alua_tpg[param])
+        for param, value in six.iteritems(alua_tpg):
+            if param != 'name' and param != 'tg_pt_gp_id':
+                try:
+                    setattr(alua_tpg_obj, param, value)
+                except:
+                    raise RTSLibError("Could not set attribute '%s' for alua tpg '%s'"
+                                      % (param, alua_tpg['name']))


### PR DESCRIPTION
Problem:
---
$ cat myconfig.json

```
{
  "storage_objects": [
    {
      "alua_tpgs": [
        {
          "alua_access_type": 0,
          "name": "glfs_tg_pt_gp",
          "tg_pt_gp_id": 1
        }
      ],
      "config": "glfs/test@192.168.124.227/block-store/2e189467-00ae-4388-bbd2-a8b4df154671",
      "name": "blockX",
      "plugin": "user",
      "size": 1073741824
    }
  ],
  "targets": []
}
```


$ targetcli restoreconfig myconfig.json
All configuration cleared
'alua_access_state'

And attributes won't be effected as per myconfig.json:
$ targetcli/backstores/user:glfs/blockX/alua/glfs_tg_pt_gp get alua alua_access_type
alua_access_type=3

Fix:
---
This patch fix the problem by calling setattr for available attribs in the
configfile and rest all will be as per kernel defaults.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>