### PR TITLE
saveconfig: dump control string containing control=value tuples

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -845,6 +845,17 @@ class UserBackedStorageObject(StorageObject):
         self._check_self()
         return int(self._parse_info('HwMaxSectors'))
 
+    def _get_control_tuples(self):
+        self._check_self()
+        tuples = []
+        # 1. max_data_area_mb
+        val = self._parse_info('MaxDataAreaMB')
+        if val != "NULL":
+            tuples.append("max_data_area_mb=%s" % val)
+        # 2. add next ...
+
+        return ",".join(tuples)
+
     def _get_config(self):
         self._check_self()
         val = self._parse_info('Config')
@@ -858,6 +869,8 @@ class UserBackedStorageObject(StorageObject):
 
     hw_max_sectors = property(_get_hw_max_sectors,
             doc="Get the max sectors per command.")
+    control_tuples = property(_get_control_tuples,
+            doc="Get the comma separated string containing control=value tuples.")
     size = property(_get_size,
             doc="Get the size in bytes.")
     config = property(_get_config,
@@ -871,6 +884,7 @@ class UserBackedStorageObject(StorageObject):
         d['size'] = self.size
         d['config'] = self.config
         d['hw_max_sectors'] = self.hw_max_sectors
+        d['control'] = self.control_tuples
 
         return d
 


### PR DESCRIPTION
Problem:
-----------
```
$ targetcli /backstores/user:glfs create blockX1 1073741824 \
  test@192.168.124.227/block-store/e59309bb-d591-4121-a891-e98ff3416446,max_data_area_mb=32

$ targetcli / saveconfig

$ cat /etc/target/saveconfig.json
{
  "storage_objects": [
    {
      "alua_tpgs": [],
      "attributes": {
        ...
      },
      "config": "glfs/test@192.168.124.227/block-store/e59309bb-d591-4121-a891-e98ff3416446",
      "hw_max_sectors": 128,
      "name": "blockX1",
      "plugin": "user",
      "size": 1073741824,
      "wwn": "3aa072d6-a007-45a3-8eac-e85b53655515"
    }
  ],
  "targets": []
}

```
Note max_data_area_mb is not dumped into the configfile and hence on restart of
target service or node reboot this storageObject property is lost.

Fix:
----
This patch make sure to dump control string containing control=value tuples, like:
```
$ cat /etc/target/saveconfig.json
    {
      ...
      "config": "glfs/test@192.168.124.227/block-store/e59309bb-d591-4121-a891-e98ff3416446",
      "control": "max_data_area_mb=32",
      ...
    }

```
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>