### PR TITLE
Add fnic2 fabric module support

### DIFF
--- a/rtslib/fabric.py
+++ b/rtslib/fabric.py
@@ -357,6 +357,13 @@ class SBPFabricModule(_BaseFabricModule):
                 break
 
 
+class Fnic2FabricModule(_BaseFabricModule):
+    def __init__(self):
+        super(Fnic2FabricModule, self).__init__('fnic2')
+        self.features = ("acls")
+        self.kernel_module = "fnic2"
+
+
 class Qla2xxxFabricModule(_BaseFabricModule):
     def __init__(self):
         super(Qla2xxxFabricModule, self).__init__('qla2xxx')
@@ -471,6 +478,7 @@ fabric_modules = {
     "vhost": VhostFabricModule,
     "xen-pvscsi": XenPvScsiFabricModule,
     "ibmvscsis": IbmvscsisFabricModule,
+    "fnic2": Fnic2FabricModule,
     }
 
 #


### PR DESCRIPTION
This PR adds support for Cisco's fnic2 fabric module, which relies on targetcli-fb and rtslib-fb for configuration with LIO.