### PR TITLE
[rtslib] saveconfig: way for block-level save with delete command

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -22,6 +22,7 @@ import os
 import stat
 import json
 import glob
+import errno
 
 from .node import CFSNode
 from .target import Target

--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -251,7 +251,7 @@ class StorageObject(CFSNode):
 
     # StorageObject public stuff
 
-    def delete(self):
+    def delete(self, save=False):
         '''
         Recursively deletes a StorageObject object.
         This will delete all attached LUNs currently using the StorageObject
@@ -274,6 +274,9 @@ class StorageObject(CFSNode):
 
         super(StorageObject, self).delete()
         self._backstore.delete()
+        if save:
+            from .root import RTSRoot, default_save_file
+            RTSRoot().save_to_file(default_save_file, '/backstores/' + self.plugin  + '/' + self._name)
 
     def is_configured(self):
         '''

--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -184,8 +184,11 @@ class StorageObject(CFSNode):
     def _parse_info(self, key):
         self._check_self()
         info = fread("%s/info" % self.path)
-        return re.search(".*%s: ([^: ]+).*" \
-                         % key, ' '.join(info.split())).group(1)
+        try:
+            return re.search(".*%s: ([^: ]+).*" \
+                             % key, ' '.join(info.split())).group(1)
+        except AttributeError:
+            return None
 
     def _get_status(self):
         self._check_self()
@@ -994,8 +997,11 @@ class _Backstore(CFSNode):
     def _parse_info(self, key):
         self._check_self()
         info = fread("%s/hba_info" % self.path)
-        return re.search(".*%s: ([^: ]+).*" \
-                         % key, ' '.join(info.split())).group(1)
+        try:
+            return re.search(".*%s: ([^: ]+).*" \
+                             % key, ' '.join(info.split())).group(1)
+        except AttributeError:
+            return None
 
     def _get_version(self):
         self._check_self()


### PR DESCRIPTION
currently, we can use block-level save feature for create command and
reconfig of different attributes, but there is no way to use block-level
feature for delete command.

This patch introduces 'save' flag (False on default), which can trigger
saveconfig internally as part of delete command.

$ targetcli /backstores/user:glfs delete test save=True
Deleted storage object test.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>
