### PR TITLE
The automatic generation of target wwn fails with underscore in hostname

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -326,7 +326,7 @@ def generate_wwn(wwn_type):
     if wwn_type == 'unit_serial':
         return str(uuid.uuid4())
     elif wwn_type == 'iqn':
-        localname = socket.gethostname().split(".")[0]
+        localname = socket.gethostname().split(".")[0].replace("_", "")
         localarch = os.uname()[4].replace("_", "")
         prefix = "iqn.2003-01.org.linux-iscsi.%s.%s" % (localname, localarch)
         prefix = prefix.strip().lower()


### PR DESCRIPTION
The auto-generation of target name fails with hostname having an underscore.

[root@iron_man ~]#
[root@iron_man ~]# targetcli /iscsi create
Created target iqn.2003-01.org.linux-iscsi.iron_man.x8664:sn.d93914fac7d4.
Created TPG 1.
Global pref auto_add_default_portal=true
Created default portal listening on all IPs (0.0.0.0), port 3260.
[root@iron_man ~]#
[root@iron_man ~]# targetcli ls
WWN not valid as: iqn, naa, eui
[root@iron_man ~]#
[root@iron_man ~]#
[root@iron_man ~]# ls /sys/kernel/config/target/iscsi/
discovery_auth                                                 lio_version
iqn.2003-01.org.linux-iscsi.iron_man.x8664:sn.d93914fac7d4
[root@iron_man ~]#

This pull request is for removing underscore in localhost name.
