### PR TITLE
discovery_auth should accept True as well

### DIFF
--- a/rtslib/fabric.py
+++ b/rtslib/fabric.py
@@ -240,7 +240,11 @@ class _BaseFabricModule(CFSNode):
         self._check_self()
         self._assert_feature('discovery_auth')
         path = "%s/discovery_auth/enforce_discovery_auth" % self.path
-        if int(enable):
+        if enable == 'True':
+            enable = 1
+        elif enable == 'False':
+            enable = 0
+        elif int(enable):
             enable = 1
         else:
             enable = 0


### PR DESCRIPTION
get discovery_auth is reporting True/False:

`iscsi > get discovery_auth`
`DISCOVERY_AUTH CONFIG GROUP`
`enable=False`

we should also be able to set it using True/False, not only 1 or 0.

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>