### PR TITLE
fix compiler warning

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -188,7 +188,7 @@ class RTSRoot(CFSNode):
         try:
             with open(save_file, "r") as f:
                 saveconf = json.loads(f.read())
-        except IOError, e:
+        except IOError as e:
             if e.errno == errno.ENOENT:
                 saveconf = {'storage_objects': [], 'targets': []}
             else:


### PR DESCRIPTION
build.log:
---------
[...]
*** Error compiling '/builddir/build/BUILDROOT/python-rtslib-2.1.fb68-1.el8.noarch/usr/lib/python3.6/site-packages/rtslib/root.py'...
  File "/usr/lib/python3.6/root.py", line 191
    except IOError, e:
                  ^
SyntaxError: invalid syntax
*** Error compiling '/builddir/build/BUILDROOT/python-rtslib-2.1.fb68-1.el8.noarch/usr/lib/python3.6/site-packages/rtslib_fb/root.py'...
  File "/usr/lib/python3.6/root.py", line 191
    except IOError, e:
[...]

Thanks to Maurizio Lombardi <mlombard@redhat.com> for finding it.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>