### PR TITLE
report the correct size for partitions

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -134,6 +134,9 @@ def _get_size_for_dev(device):
     except (KeyError, UnicodeDecodeError, ValueError):
         return 0
 
+    if device['DEVTYPE'] == 'partition':
+        attributes = device.parent.attributes
+
     try:
         logical_block_size = attributes.asint('queue/logical_block_size')
     except (KeyError, UnicodeDecodeError, ValueError):


### PR DESCRIPTION
If you use a partition instead of the whole device as the backstore device,
rtslib will always report its size as 0 bytes.

This happens because rtslib tries to read the "queue/logical_block_size"
attribute, which can only be found in the parent's node.
This patch fixes the bug by loading the parent node's attributes if
it detects that the device is a partition.

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>