### PR TITLE
Handle attribute pi_prot_format being write-only

### DIFF
--- a/rtslib/node.py
+++ b/rtslib/node.py
@@ -20,6 +20,7 @@ under the License.
 
 import os
 import stat
+import errno
 from .utils import fread, fwrite, RTSLibError, RTSLibNotInCFS
 
 
@@ -165,7 +166,14 @@ class CFSNode(object):
         if not os.path.isfile(path):
             raise RTSLibError("Cannot find attribute: %s" % attribute)
         else:
-            return fread(path)
+            try:
+                res = fread(path)
+            except IOError as e:
+                if e.errno == errno.EACCES:
+                    # assume write-only, so just return 0
+                    return 0
+                raise
+            return res
 
     def set_parameter(self, parameter, value):
         '''


### PR DESCRIPTION
A recent kernel changes (see commit 6baca7601bdee2e5) make
the pi_prot_format protection information attribute write-only,
since reading it always returned 0.

But rtslib tries to read everything in the "attrib" (attribute)
directory, so reading pi_prot_format raises an access error,
since reading a write-only file is not allowed. So catch this
exception and handle it, assuming the value is 0 if we cannot
read the attribute.

The error stack trace looks like:

`/> saveconfig
Last 10 configs saved in /etc/target/backup.
Traceback (most recent call last):
  File "/usr/bin/targetcli", line 121, in <module>
    main()
  File "/usr/bin/targetcli", line 111, in main
    shell.run_interactive()
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 905, in run_interactive
    self._cli_loop()
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 734, in _cli_loop
    self.run_cmdline(cmdline)
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 848, in run_cmdline
    self._execute_command(path, command, pparams, kparams)
  File "/usr/lib/python3.6/site-packages/configshell_fb/shell.py", line 823, in _execute_command
    result = target.execute_command(command, pparams, kparams)
  File "/usr/lib/python3.6/site-packages/configshell_fb/node.py", line 1406, in execute_command
    return method(*pparams, **kparams)
  File "/usr/lib/python3.6/site-packages/targetcli/ui_root.py", line 98, in ui_command_saveconfig
    self.rtsroot.save_to_file(savefile)
  File "/usr/lib/python3.6/site-packages/rtslib_fb/root.py", line 303, in save_to_file
    f.write(json.dumps(self.dump(), sort_keys=True, indent=2))
  File "/usr/lib/python3.6/site-packages/rtslib_fb/root.py", line 188, in dump
    d['storage_objects'] = [so.dump() for so in self.storage_objects]
  File "/usr/lib/python3.6/site-packages/rtslib_fb/root.py", line 188, in <listcomp>
    d['storage_objects'] = [so.dump() for so in self.storage_objects]
  File "/usr/lib/python3.6/site-packages/rtslib_fb/tcm.py", line 673, in dump
    d = super(FileIOStorageObject, self).dump()
  File "/usr/lib/python3.6/site-packages/rtslib_fb/tcm.py", line 308, in dump
    d = super(StorageObject, self).dump()
  File "/usr/lib/python3.6/site-packages/rtslib_fb/node.py", line 225, in dump
    attrs[item] = int(self.get_attribute(item))
  File "/usr/lib/python3.6/site-packages/rtslib_fb/node.py", line 168, in get_attribute
    return fread(path)
  File "/usr/lib/python3.6/site-packages/rtslib_fb/utils.py", line 100, in fread
    with open(path, 'r') as file_fd:
PermissionError: [Errno 13] Permission denied: '/sys/kernel/config/target/core/fileio_0/myfile-1/attrib/pi_prot_format'
`
I cannot think of any other simple way of handling write-only attributes, especially since there are no others to generalize with.