### PR TITLE
Handle write-only attributes.

### DIFF
--- a/rtslib/node.py
+++ b/rtslib/node.py
@@ -122,17 +122,21 @@ class CFSNode(object):
 
     # CFSNode public stuff
 
-    def list_parameters(self, writable=None):
+    def list_parameters(self, writable=None, readable=None):
         '''
-        @param writable: If None (default), returns all parameters, if True,
-        returns read-write parameters, if False, returns just the read-only
-        parameters.
+        @param writable: If None (default), return all parameters despite
+        their writability. If True, return only writable parameters. If
+        False, return only non-writable parameters.
         @type writable: bool or None
+        @param readable: If None (default), return all parameters despite
+        their readability. If True, return only readable parameters. If
+        False, return only non-readable parameters.
+        @type readable: bool or None
         @return: The list of existing RFC-3720 parameter names.
         '''
         self._check_self()
         path = "%s/param" % self.path
-        return self._list_files(path, writable)
+        return self._list_files(path, writable, readable)
 
     def list_attributes(self, writable=None, readable=None):
         '''
@@ -242,7 +246,7 @@ class CFSNode(object):
                 attrs[item] = self.get_attribute(item)
         if attrs:
             d['attributes'] = attrs
-        for item in self.list_parameters(writable=True):
+        for item in self.list_parameters(writable=True, readable=True):
             params[item] = self.get_parameter(item)
         if params:
             d['parameters'] = params

--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -1302,11 +1302,11 @@ class Group(object):
         for mem in self._mem_func(self):
             setattr(mem, prop, value)
 
-    def list_attributes(self, writable=None):
-        return self._get_first_member().list_attributes(writable)
+    def list_attributes(self, writable=None, readable=None):
+        return self._get_first_member().list_attributes(writable, readable)
 
-    def list_parameters(self, writable=None):
-        return self._get_first_member().list_parameters(writable)
+    def list_parameters(self, writable=None, readable=None):
+        return self._get_first_member().list_parameters(writable, readable)
 
     def set_attribute(self, attribute, value):
         for obj in self._mem_func(self):


### PR DESCRIPTION
A recent kernel change (see commit 6baca7601bdee2e5) makes
the pi_prot_format protection information attribute write-only,
since it always returned 0 when being read. This commit is being
reverted, but it still brought up the prospect of write-only
attributes.

Currently, when doing a dump(), rtslib iterates through all
readable attributes to decide which ones to save as part of
our current state, but saving write-only attributes
makes no sense, since we cannot read them to capture their
value. Towards this end, enhande the _list_files() internal
method to allow filtering on whether the file is writable
as well as whether or not it is readable. Then modify
list_attributes() to allow this new parameter and modify
dump() to request only R/W attributes.