### PR TITLE
saveconfig: add hw_block_size support in control string

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -873,7 +873,10 @@ class UserBackedStorageObject(StorageObject):
         val = self._parse_info('MaxDataAreaMB')
         if val != "NULL":
             tuples.append("max_data_area_mb=%s" % val)
-        # 2. add next ...
+        val = self.get_attribute('hw_block_size')
+        if val != "NULL":
+            tuples.append("hw_block_size=%s" % val)
+        # 3. add next ...
 
         return ",".join(tuples)
 


### PR DESCRIPTION
$ targetcli /backstores/user:glfs create name=block size=1048576 \
  cfgstring=hosting-volume@192.168.195.164/block-store/d85244f7-88e9-4b28-922d-373fa9f59f24 \
  control=max_data_area_mb=64,hw_block_size=1024 wwn=d85244f7-88e9-4b28-922d-373fa9f59f24

$ targetcli / saveconfig

$ cat /etc/target/saveconfig.json
{
  "storage_objects": [
    {
      "alua_tpgs": [],
      "attributes": {
        ...
      },
      "config": "glfs/hosting-volume@192.168.195.164/block-store/d85244f7-88e9-4b28-922d-373fa9f59f24",
      "control": "max_data_area_mb=64,hw_block_size=1024",
      "hw_max_sectors": 128,
      "name": "block",
      "plugin": "user",
      "size": 1048576,
      "wwn": "d85244f7-88e9-4b28-922d-373fa9f59f24"
    }
  ],
  "targets": []
}

Signed-off-by: Xiubo Li <xiubli@redhat.com>