### PR TITLE
rtslib: fix __version__

### DIFF
--- a/rtslib/__init__.py
+++ b/rtslib/__init__.py
@@ -16,7 +16,7 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-if __name__ == "rtslib":
+if __name__ == "rtslib-fb":
     from warnings import warn
     warn("'rtslib' package name for rtslib-fb is deprecated, please"
          + " instead import 'rtslib_fb'", UserWarning, stacklevel=2)
@@ -36,8 +36,8 @@ from .tcm import StorageObjectFactory
 
 from .alua import ALUATargetPortGroup
 
-__version__ = 'GIT_VERSION'
+__version__ = '2.1.69'
 __author__ = "Jerome Martin <jxm@risingtidesystems.com>"
-__url__ = "http://www.risingtidesystems.com"
-__description__ = "API for RisingTide Systems generic SCSI target."
-__license__ = __doc__
+__url__ = 'http://github.com/open-iscsi/rtslib-fb'
+__description__ = 'API for Linux kernel SCSI target (aka LIO)'
+__license__ = 'Apache 2.0'

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,25 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
+import os
+import re
 from setuptools import setup
+
+# Get version without importing.
+init_file_path = os.path.join(os.path.dirname(__file__), 'rtslib/__init__.py')
+
+with open(init_file_path) as f:
+    for line in f:
+        match = re.match(r"__version__.*'([0-9.]+)'", line)
+        if match:
+            version = match.group(1)
+            break
+    else:
+        raise Exception("Couldn't find version in setup.py")
 
 setup (
     name = 'rtslib-fb',
-    version = '2.1.69',
+    version = version,
     description = 'API for Linux kernel SCSI target (aka LIO)',
     license = 'Apache 2.0',
     maintainer = 'Andy Grover',


### PR DESCRIPTION
Before:
$ python -c "import rtslib_fb; print(rtslib_fb.\_\_version_\_)"
GIT_VERSION

After:
$ python -c "import rtslib_fb; print(rtslib_fb.\_\_version_\_)"
2.1.69

Also rectified few other public exported variables

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>