### PR TITLE
restoreconfig: fix skipping of targets [re]loading

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -433,8 +433,8 @@ class RTSRoot(CFSNode):
                 # Instantiate target
                 Target.setup(fm_obj, t, err_func)
 
-            if target:
-                break
+                if target:
+                    break
 
         return errors
 


### PR DESCRIPTION
Problem:
-----------
'targetcli restoreconfig [savefile] [target=...]' works for first target only
in the saveconfig.json and fails/skips for others silently.

Solution:
-----------
Just an indentation fix, yet very severe.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>