### PR TITLE
save_to_file: fix fd open mode

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -479,7 +479,7 @@ class RTSRoot(CFSNode):
         finally:
             os.umask(umask_original)
 
-        with os.fdopen(fdesc, 'w+') as f:
+        with os.fdopen(fdesc, 'w') as f:
             f.write(json.dumps(saveconf, sort_keys=True, indent=2))
             f.write("\n")
             f.flush()


### PR DESCRIPTION
since we used O_WRONLY with os.open(), lets stick to
same mode with os.fdopen() too

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>