### PR TITLE
Fix fail when target_core_mod doesn't exists

### DIFF
--- a/rtslib/fabric.py
+++ b/rtslib/fabric.py
@@ -489,4 +489,7 @@ class FabricModule(object):
 
     @classmethod
     def list_registered_drivers(cls):
-        return os.listdir('/sys/module/target_core_mod/holders')
+        try:
+            return os.listdir('/sys/module/target_core_mod/holders')
+        except OSError:
+            return []


### PR DESCRIPTION
On my systems (Linux 5.2.1 and 5.4.38 compiled without any module, but TARGET_CORE built-in), it appears that the directory `/sys/module/iscsi_target_mod/` doesn't exist, causing the following error when running `targetctl`:

```
[Errno 2] No such file or directory: '/sys/module/target_core_mod/holders'
```

The proposed commit returns an empty list instead of an exception, when trying to list the content of the directory.