### PR TITLE
rtslib: Use O_RDWR for sg devices alone.

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -114,7 +114,11 @@ def is_dev_in_use(path):
     '''
     path = os.path.realpath(str(path))
     try:
-        file_fd = os.open(path, os.O_EXCL|os.O_NDELAY|os.O_RDWR)
+        device = pyudev.Device.from_device_file(_CONTEXT, path)
+        if device.subsystem == u'scsi_generic':
+            file_fd = os.open(path, os.O_EXCL|os.O_NDELAY|os.O_RDWR)
+        else:
+            file_fd = os.open(path, os.O_EXCL|os.O_NDELAY)
     except OSError:
         return True
     else:


### PR DESCRIPTION
Using O_RDWR flag for read-only devices will always result in
is_dev_in_use() to return False while sg devices require O_RDWR flag.
Hence, determine this difference programmatically and use the flags
appropriately.

Resolves https://github.com/open-iscsi/rtslib-fb/issues/170

Fixes: 964520037320 ("Fix EPERM errors with scsi_generic devices")
Signed-off-by: Sudhakar Panneerselvam <sudhakar.panneerselvam@oracle.com>