### PR TITLE
Relax restrictions on TPG Tag range

### DIFF
--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -159,7 +159,7 @@ class TPG(CFSNode):
         @param parent_target: The parent Target object of the TPG.
         @type parent_target: Target
         @param tag: The TPG Tag (TPGT).
-        @type tag: int > 0
+        @type tag: positive int
         @param mode:An optionnal string containing the object creation mode:
             - I{'any'} means the configFS object will be either looked up or
               created.
@@ -181,8 +181,8 @@ class TPG(CFSNode):
                 raise RTSLibError("Cannot find an available TPG Tag")
         else:
             tag = int(tag)
-            if not tag > 0:
-                raise RTSLibError("The TPG Tag must be >0")
+            if tag < 0:
+                raise RTSLibError("The TPG Tag must be >=0")
         self._tag = tag
 
         if isinstance(parent_target, Target):


### PR DESCRIPTION
Currently rtslib forbids TPG Tag 0. According to
https://tools.ietf.org/html/rfc7143#section-13.9 this is perfectly legal
value, and I've tested it with Linux, Windows, ESXi and AIX initiators.

This commit relaxes the restriction and allows TPG Tag to be 0. I've
kept current behavior in automatic tags assignment so nothing changes
there (e.g. the first TPG will be 1 unless the user explicitly tells
otherwise).