### PR TITLE
tcmu: add support for config param data_pages_per_blk

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -876,7 +876,11 @@ class UserBackedStorageObject(StorageObject):
         val = self.get_attribute('hw_block_size')
         if val != "NULL":
             tuples.append("hw_block_size=%s" % val)
-        # 3. add next ...
+        # 3. data_pages_per_blk
+        val = self._parse_info('DataPagesPerBlk')
+        if val != "NULL":
+            tuples.append("data_pages_per_blk=%s" % val)
+        # 4. add next ...
 
         return ",".join(tuples)
 


### PR DESCRIPTION
Starting from kernel 5.13 tcmu (user based backend) supports
config parameter DataPagesPerBlk alias data_pages_per_blk.

This change enables rtslib to save the new config parameter
to saveconfig.json.

Signed-off-by: Bodo Stroesser <bostroesser@gmail.com>

#####

Short explanation of the new tcmu config param:

The parameter allows to specify what granularity is used in
data area provided via uio device. Data space now appears to
userspace as chunks of data_pages_per_blk * PAGE_SIZE.
If the default value 1 of data_pages_per_blk is not changed,
tcmu behaves like unchanged.

Setting data_pages_per_blk > 1 allows tcmu to allocate less
but bigger chunks, which makes allocation quicker. Also
userspace will see less iovecs per data transfer. If chunk
size is as big as biggest possible data transfer, userspace
will see consecutive buffers only.