### PR TITLE
Check whether the enable attribute exists before fread

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -282,15 +282,14 @@ class StorageObject(CFSNode):
         '''
         @return: True if the StorageObject is configured, else returns False
         '''
-
         self._check_self()
         path = "%s/enable" % self.path
-        try:
-            configured = fread(path)
-        except IOError:
+        # If the StorageObject does not have the enable attribute,
+        # then it is always enabled.
+        if os.path.isfile(path):
+            return bool(int(fread(path)))
+        else:
             return True
-
-        return bool(int(configured))
 
     version = property(_get_version,
             doc="Get the version of the StorageObject's backstore")


### PR DESCRIPTION
I think the backend storage is not configured when an IOError exception occurs.

Signed-off-by: Zou Mingzhe <mingzhe.zou@easystack.cn>