### PR TITLE
dbroot: let the user change the dbroot directory freely.

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -167,20 +167,20 @@ class RTSRoot(CFSNode):
             return
         self._dbroot = fread(dbroot_path)
         if self._dbroot != self._preferred_dbroot:
-            if len(FabricModule.list_registered_drivers()) != 0:
-                # Writing to dbroot_path after drivers have been registered will make the kernel emit this error:
-                # db_root: cannot be changed: target drivers registered
-                from warnings import warn
-                warn("Cannot set dbroot to {}. Target drivers have already been registered."
-                     .format(self._preferred_dbroot))
-                return
-
             try:
                 fwrite(dbroot_path, self._preferred_dbroot+"\n")
             except:
                 if not os.path.isdir(self._preferred_dbroot):
                     raise RTSLibError("Cannot set dbroot to {}. Please check if this directory exists."
                                       .format(self._preferred_dbroot))
+                else
+                    # Writing to dbroot_path after devices have been registered will make the kernel emit this error:
+                    # db_root: cannot be changed: target devices registered
+                    from warnings import warn
+                    warn("Cannot set dbroot to {}. Target devices have already been registered."
+                         .format(self._preferred_dbroot))
+                    return
+
             self._dbroot = fread(dbroot_path)
 
     def _get_dbroot(self):


### PR DESCRIPTION
Thanks to a new kernel patch [1], the LIO driver now lets the user change
the dbroot directory even if some target modules are already registered
(if some conditions are met).

rtslib should let the user set their preferred root directory without
arbitrary checks and let the kernel decide if this is allowed or not.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/mkp/scsi.git/commit/?h=for-next&id=80890c5ea068661d6fe4a34beb362ca0f2c49c90

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>