### PR TITLE
rtslib: Don't create /var/run on import

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -34,8 +34,6 @@ from .utils import is_dev_in_use, get_blockdev_type
 from .utils import get_size_for_blk_dev, get_size_for_disk_name
 
 lock_file = '/var/run/rtslib_backstore.lock'
-if not os.path.exists('/var/run'):
-    os.makedirs('/var/run')
 
 def storage_object_get_alua_support_attr(so):
     '''
@@ -1001,6 +999,8 @@ class _Backstore(CFSNode):
                                      (self._plugin, name))
             else:
                 # Allocate new index value
+                if not os.path.exists('/var/run'):
+                    os.makedirs('/var/run')
                 lkfd = open(lock_file, 'w+')
                 fcntl.flock(lkfd, fcntl.LOCK_EX)
                 indexes = set(bs_cache.values())


### PR DESCRIPTION
Importing the module alone shouldn't require root privileges. This fixes simple import tests in downstream projects.