### PR TITLE
setup.py: match __version__ with optional trailing ".g<hash>".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ init_file_path = os.path.join(os.path.dirname(__file__), 'rtslib/__init__.py')
 
 with open(init_file_path) as f:
     for line in f:
-        match = re.match(r"__version__.*'([0-9.]+)'", line)
+        match = re.match(r"__version__.*'([0-9.]+)(\.g[0-9a-f]+)?'", line)
         if match:
             version = match.group(1)
             break


### PR DESCRIPTION
Will match __version__ with trailing .g<hash> but will not include .g<hash> in installed module version.

Fixes #188.

Signed-off-by: Brendan Cunningham <bcunningham@cornelisnetworks.com>