### PR TITLE
Silently ignore OSError on os.close()

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -115,7 +115,10 @@ def is_dev_in_use(path):
     except OSError:
         return True
     else:
-        os.close(file_fd)
+        try:
+            os.close(file_fd)
+        except OSError:
+            pass
         return False
 
 def _get_size_for_dev(device):


### PR DESCRIPTION
There's a bug ( #196 ) that causes trying to create tape passthrough entries to fail on os.close(). As this should always succeed or fail gracefully, silently ignoring the failed close() here should be safe.