### PR TITLE
Add rtslib_fb import compability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,13 @@ debian/rtslib-doc.debianebhelper.log
 debian/rtslib-doc.substvars
 debian/rtslib-doc/
 debian/tmp/
-dist/*
+dist/
 doc/*
 *.pyc
 debian/rtslib-doc.debhelper.log
 venv/
+.venv/
 .idea
 *egg-info/
+.mypy_cache/
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: [--fix]

--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -415,7 +415,7 @@ def modprobe(module):
         import kmod.error
         import kmod.Kmod
     except ImportError:
-        out = subprocess.run(f"modprobe {module}", shell=True, capture_output=True, check=False)  # noqa: S602, S607
+        out = subprocess.run(f"modprobe {module}", shell=True, capture_output=True, check=False)  # noqa: S602
         if out.returncode != 0:
             raise RTSLibError(out.stderr.decode().rstrip())
         return

--- a/rtslib_fb.py
+++ b/rtslib_fb.py
@@ -1,0 +1,21 @@
+"""
+rtslib_fb.py - Backwards compatibility module for rtslib
+
+This module provides backwards compatibility for code that imports 'rtslib_fb'.
+It re-exports all public names from the 'rtslib' module.
+
+Usage:
+    from rtslib_fb import RTSRoot, Target, TPG  # etc.
+
+Note: This compatibility layer may be deprecated in future versions.
+Please consider updating your imports to use 'rtslib' directly.
+"""
+
+import rtslib
+from rtslib import *  # noqa: F403
+
+# Explicitly import and re-export submodules
+from rtslib import alua, fabric, node, root, target, tcm, utils  # noqa: F401
+
+# Re-export all public names from rtslib
+__all__ = rtslib.__all__


### PR DESCRIPTION
I think it would be nice to get rid of the`__all__`, but from what I can see in targetcli_fb it's not really possible without changing it simultaneously. 