### PR TITLE
Explicitly set build target wheel packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ Homepage = "http://github.com/open-iscsi/rtslib-fb"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.targets.wheel]
+packages = [
+    "rtslib",
+    "rtslib_fb.py"
+]
+
 [tool.hatch.envs.default]
 dependencies = [
     "ruff",


### PR DESCRIPTION
After changing the package name from `rtslib` to `rtslib-fb` to be able to publish on PyPI, the build system no longer correctly autodetects the rtslib package, as it matches the rtslib_fb.py file only. This change will set the rtslib and rtslib_fb.py explicitly in the same way as in configshell-fb, which is using the same compatibility/legacy layers.  

Tested on Fedora 41, both rtslib and rtslib_fb imports are working as expected and source tarball seems to contain everything.