### PR TITLE
Remove use of /usr/bin/python

### DIFF
--- a/rtslib/targetctl.py
+++ b/rtslib/targetctl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 '''
 targetctl
 


### PR DESCRIPTION
The targetctl.py script was using /usr/bin/python, even though this package has been ported to python3.

This makes installing it on modern systems fail. Change it to /usr/bin/python3.