### PR TITLE
fabric: fix search path for SRPT wwn

### DIFF
--- a/rtslib/fabric.py
+++ b/rtslib/fabric.py
@@ -451,7 +451,7 @@ class SRPTFabricModule(_BaseFabricModule):
 
     @property
     def wwns(self):
-        for wwn_file in Path("/sys/class/infiniband").glob("**/ports/*/gids/0"):
+        for wwn_file in Path("/sys/class/infiniband").glob("*/ports/*/gids/0"):
             yield f"ib.{fread(wwn_file).replace(':', '')}"
 
 


### PR DESCRIPTION
When converted to path link, Infiniband gid search path was replaced with a double wildcard '**' causing no WWNs to be found and SRPT to be unusable: No such path /srpt

This due to HCA in /sys/class/infiniband being symlinks: $ ll /sys/class/infiniband
total 0
lrwxrwxrwx 1 root root 0 Jun 23 11:31 mlx5_0 -> ../../devices/pci0000:00/0000:00:02.6/0000:07:00.0/infiniband/mlx5_0

recurse_symlinks=True cannot be used here as HCA directories contains a 'subsystem' symlink
 pointing back to /sys/class/infiniband

Replace the double wildcard with a single one to revert to the previous behaviour and be consistent with other fabrics.

Fixes: d3abd5df9e06 ("Convert codebase to pathlib")

Reviewed-by: Lee Duncan <lduncan@suse.com>