### PR TITLE
Add missing f-string in configfs mount cmd

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -430,7 +430,7 @@ def mount_configfs():
     config_dir = "/sys/kernel/config"
     config_path = Path(config_dir)
     if not config_path.is_mount():
-        cmdline = ["mount -t configfs none {config_dir}"]
+        cmdline = [f"mount -t configfs none {config_dir}"]
         out = subprocess.run(cmdline, shell=True, capture_output=True, check=False)  # noqa: S602
         if out.returncode != 0 and not config_path.is_mount():
             raise RTSLibError("Cannot mount configfs")


### PR DESCRIPTION
Usually, this code is never reached.

But under some circumstances (running in a container, or configfs was not mounted at boot), this fails with:

```
mount: {config_dir}: mount point does not exist
```

example:
```
Traceback (most recent call last):
  File "/var/lib/kolla/venv/bin/cinder-rtstool", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/var/lib/kolla/venv/lib64/python3.12/site-packages/cinder/cmd/rtstool.py", line 287, in main
    create(backing_device, name, userid, password, iser_enabled,
  File "/var/lib/kolla/venv/lib64/python3.12/site-packages/cinder/cmd/rtstool.py", line 44, in create
    rtsroot = rtslib_fb.root.RTSRoot()
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/kolla/venv/lib64/python3.12/site-packages/rtslib/root.py", line 86, in __init__
    mount_configfs()
  File "/var/lib/kolla/venv/lib64/python3.12/site-packages/rtslib/utils.py", line 437, in mount_configfs
    raise RTSLibError("Cannot mount configfs")
rtslib.utils.RTSLibError: Cannot mount configfs
```